### PR TITLE
Don't depend on go-mode

### DIFF
--- a/go-tag.el
+++ b/go-tag.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/brantou/emacs-go-tag
 ;; Keywords: tools
 ;; Version: 1.1.0
-;; Package-Requires: ((emacs "24.0")(go-mode "1.5.0"))
+;; Package-Requires: ((emacs "24.0"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -41,8 +41,6 @@
 ;;
 
 ;;; Code:
-
-(require 'go-mode)
 
 (defgroup go-tag nil
   "Modify field tag for struct fields."
@@ -97,6 +95,76 @@ It can either be displayed in its own buffer, in the echo area, or not at all."
                 ",")
                ","))
              ","))
+
+(defun go-tag--delete-whole-line (&optional arg)
+  "Delete the current line without putting it in the `kill-ring'.
+Derived from function `kill-whole-line'.  ARG is defined as for that
+function."
+  (setq arg (or arg 1))
+  (if (and (> arg 0)
+           (eobp)
+           (save-excursion (forward-visible-line 0) (eobp)))
+      (signal 'end-of-buffer nil))
+  (if (and (< arg 0)
+           (bobp)
+           (save-excursion (end-of-visible-line) (bobp)))
+      (signal 'beginning-of-buffer nil))
+  (cond ((zerop arg)
+         (delete-region (progn (forward-visible-line 0) (point))
+                        (progn (end-of-visible-line) (point))))
+        ((< arg 0)
+         (delete-region (progn (end-of-visible-line) (point))
+                        (progn (forward-visible-line (1+ arg))
+                               (unless (bobp)
+                                 (backward-char))
+                               (point))))
+        (t
+         (delete-region (progn (forward-visible-line 0) (point))
+                        (progn (forward-visible-line arg) (point))))))
+
+(defun go-tag--apply-rcs-patch (patch-buffer)
+  "Apply an RCS-formatted diff from PATCH-BUFFER to the current buffer."
+  (let ((target-buffer (current-buffer))
+        ;; Relative offset between buffer line numbers and line numbers
+        ;; in patch.
+        ;;
+        ;; Line numbers in the patch are based on the source file, so
+        ;; we have to keep an offset when making changes to the
+        ;; buffer.
+        ;;
+        ;; Appending lines decrements the offset (possibly making it
+        ;; negative), deleting lines increments it. This order
+        ;; simplifies the forward-line invocations.
+        (line-offset 0)
+        (column (current-column)))
+    (save-excursion
+      (with-current-buffer patch-buffer
+        (goto-char (point-min))
+        (while (not (eobp))
+          (unless (looking-at "^\\([ad]\\)\\([0-9]+\\) \\([0-9]+\\)")
+            (error "Invalid rcs patch or internal error in go-tag--apply-rcs-patch"))
+          (forward-line)
+          (let ((action (match-string 1))
+                (from (string-to-number (match-string 2)))
+                (len  (string-to-number (match-string 3))))
+            (cond
+             ((equal action "a")
+              (let ((start (point)))
+                (forward-line len)
+                (let ((text (buffer-substring start (point))))
+                  (with-current-buffer target-buffer
+                    (cl-decf line-offset len)
+                    (goto-char (point-min))
+                    (forward-line (- from len line-offset))
+                    (insert text)))))
+             ((equal action "d")
+              (with-current-buffer target-buffer
+                (goto-line (- from line-offset))
+                (cl-incf line-offset len)
+                (go-tag--delete-whole-line len)))
+             (t
+              (error "Invalid rcs patch or internal error in go-tag--apply-rcs-patch")))))))
+    (move-to-column column)))
 
 ;;;###autoload
 (defun go-tag-open-github()


### PR DESCRIPTION
As far as I can see, this doesn't actually depend on go-mode. So this will make it work OK when using go-ts-mode, for example.

Fixes #5 